### PR TITLE
feat(gtm): split into head + body components for Inertia layouts

### DIFF
--- a/src/Components/GtmBody.php
+++ b/src/Components/GtmBody.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace SmartCms\Kit\Components;
+
+use Closure;
+use Illuminate\Contracts\View\View;
+use Illuminate\View\Component;
+
+/**
+ * Renders the Google Tag Manager <noscript> fallback iframe.
+ *
+ * Per Google's install instructions this must be placed immediately
+ * after the opening <body> tag so users with JavaScript disabled still
+ * register a page view.
+ *
+ * Pair with <x-kit-gtm-head /> placed inside <head> for the bootstrap
+ * script.
+ */
+class GtmBody extends Component
+{
+    public ?string $gtm;
+
+    public function __construct()
+    {
+        $this->gtm = app('s')->get('gtm', null);
+    }
+
+    public function render(): View | Closure | string
+    {
+        return <<<'blade'
+            @if ($gtm)
+                <noscript>
+                    <iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtm }}" height="0" width="0" style="display: none; visibility: hidden"></iframe>
+                </noscript>
+            @endif
+        blade;
+    }
+}

--- a/src/Components/GtmHead.php
+++ b/src/Components/GtmHead.php
@@ -7,14 +7,16 @@ use Illuminate\Contracts\View\View;
 use Illuminate\View\Component;
 
 /**
- * @deprecated since 1.x — emits both the GTM script and the noscript
- * fallback in a single slot, which only fits Blade-rendered layouts
- * where both can live together at the end of <body>. For Inertia/React
- * starters (and to match Google's recommended placement) use
- * <x-kit-gtm-head /> in <head> and <x-kit-gtm-body /> right after the
- * opening <body> tag instead. Will be removed in 2.0.
+ * Renders the Google Tag Manager bootstrap script.
+ *
+ * Per Google's install instructions this block must be placed as high
+ * in the <head> as possible so the dataLayer is initialized before any
+ * page scripts try to push events.
+ *
+ * Pair with <x-kit-gtm-body /> placed immediately after <body> open
+ * for the <noscript> fallback.
  */
-class Gtm extends Component
+class GtmHead extends Component
 {
     public ?string $gtm;
 
@@ -27,9 +29,6 @@ class Gtm extends Component
     {
         return <<<'blade'
             @if ($gtm)
-                <noscript>
-                    <iframe src="https://www.googletagmanager.com/ns.html?id={{ $gtm }}" height="0" width="0" style="display: none; visibility: hidden"></iframe>
-                </noscript>
                 <script async>
                     (function(w, d, s, l, i) {
                         w[l] = w[l] || [];

--- a/src/KitServiceProvider.php
+++ b/src/KitServiceProvider.php
@@ -28,6 +28,8 @@ use SmartCms\Kit\Commands\SyncBlockSchemas;
 use SmartCms\Kit\Commands\Update;
 use SmartCms\Kit\Components\Footer;
 use SmartCms\Kit\Components\Gtm;
+use SmartCms\Kit\Components\GtmBody;
+use SmartCms\Kit\Components\GtmHead;
 use SmartCms\Kit\Components\Header;
 use SmartCms\Kit\Components\Heading;
 use SmartCms\Kit\Components\Image;
@@ -98,7 +100,7 @@ class KitServiceProvider extends PackageServiceProvider
             ->hasRoute('static')
             ->hasRoute('admin')
             ->hasViews('kit')
-            ->hasViewComponents('kit', Layout::class, Footer::class, Theme::class, Gtm::class, Header::class, PageComponent::class, Heading::class, Image::class, Link::class)
+            ->hasViewComponents('kit', Layout::class, Footer::class, Theme::class, Gtm::class, GtmHead::class, GtmBody::class, Header::class, PageComponent::class, Heading::class, Image::class, Link::class)
             ->hasInstallCommand(function (InstallCommand $command): void {
                 $command
                     ->publish('images')


### PR DESCRIPTION
## Summary

The existing \`<x-kit-gtm />\` emits the GTM bootstrap **script** and the **noscript iframe fallback** together in a single slot. That only works in Blade-rendered layouts where both can live at the end of \`<body>\` — and even there it's not where Google wants them. Per the official install instructions:

- The bootstrap **script** must be as high in \`<head>\` as possible so \`dataLayer\` is initialized before any page scripts try to push events.
- The **\`<noscript>\` iframe** must be immediately after the opening \`<body>\` tag so users with JavaScript disabled still register a page view.

In the Inertia/React starter's \`app.blade.php\`, \`<x-kit-gtm />\` currently sits at the end of \`<body>\` after \`@inertia\`, which means the GTM script fires **after** React hydration — early analytics events can be lost, and no-JS users don't get the fallback iframe either.

## Changes

Introduces two new components that each render only one half:

- \`<x-kit-gtm-head />\` → renders only the \`<script>\` block, drop into \`<head>\`
- \`<x-kit-gtm-body />\` → renders only the \`<noscript><iframe>\`, drop immediately after \`<body>\` open

Both read \`app('s')->get('gtm')\` the same way and are no-ops when the setting is empty.

The old \`<x-kit-gtm />\` is kept untouched for backward compatibility with existing Blade-only layouts and marked \`@deprecated since 1.x\` via PHPDoc — it'll be removed in 2.0. Inertia/React starters should migrate to the split pair.

## Follow-up

The starter's \`app.blade.php\` will be updated in a parallel PR (\`s-cms/starter#feature/post-kit-update\`) to use \`<x-kit-gtm-head />\` in \`<head>\` and \`<x-kit-gtm-body />\` right after \`<body>\` open, replacing the current body-end \`<x-kit-gtm />\`.

## Test plan

- [ ] Set a GTM ID in Settings → SEO → Google Tag
- [ ] Render a page in a Blade layout that uses \`<x-kit-gtm-head />\` in \`<head>\` and \`<x-kit-gtm-body />\` after \`<body>\` open → view source, confirm both blocks appear in the expected positions
- [ ] Clear the GTM ID in settings → confirm neither component emits any output
- [ ] Existing \`<x-kit-gtm />\` still renders both blocks as before (backward compat)